### PR TITLE
Update action runtime to node20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4.0.1
         with:
           cache: 'yarn'
-          node-version: '16.x'
+          node-version: '20.x'
 
       - name: Create coverage directory and clover.xml
         run: |

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ outputs:
     description: "Indicates whether at least one pattern was provided"
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
   post: 'dist/cleanup/index.js'
 


### PR DESCRIPTION
Not sure if this will require other changes. We rely on tj-actions/glob via tj-actions/changed-files (I think)! We're trying to avoid this warning:

<img width="848" alt="image" src="https://github.com/tj-actions/glob/assets/15040698/271cf908-3b44-4e01-b5a7-94aa32efde92">
